### PR TITLE
Enable to read the port parameter

### DIFF
--- a/launch/lab_usb_9axisimu_driver.launch
+++ b/launch/lab_usb_9axisimu_driver.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node pkg="lab_usb_9axisimu_driver" name="lab_usb_9axisimu_driver" type="lab_usb_9axisimu_driver">
+  <node pkg="lab_usb_9axisimu_driver" name="lab_usb_9axisimu_driver" type="lab_usb_9axisimu_driver" required="true" output="screen">
     <param name="port" value="/dev/ttyACM0"/>
   </node>
 </launch>

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -19,7 +19,8 @@ using namespace std;
 
 int main(int argc, char **argv){
 
-    ros::init(argc, argv, "lab_usb_9axisimu_driver");
+    const string node_name = "lab_usb_9axisimu_driver";
+    ros::init(argc, argv, node_name);
     ros::NodeHandle n;
 
     string port,frame_id;
@@ -40,6 +41,8 @@ int main(int argc, char **argv){
     double magnetic_field_stdev;
 
     n.param("port", port,string("/dev/ttyACM0"));
+    n.getParam(node_name + "/port", port);
+
     n.param("frame_id", frame_id,string("imu_link"));
     n.param("linear_acceleration_stdev", linear_acceleration_stdev, 0.023145);
     n.param("angular_velocity_stdev", angular_velocity_stdev, 0.0010621);


### PR DESCRIPTION
I found a bug that the parameter "port" in the launch file was not reflected. 